### PR TITLE
Add missing pybtex dependency to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ gfm = "*"
 requests = "*"
 autolink = "*"
 bibtexparser = "*"
+pybtex = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
When trying to build the project, the build script spat out an error about a missing package called "pybtex", so I added it to the Pipfile and it resolved the error.